### PR TITLE
Undefined className bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function(babel) {
             css && style && css.parentPath.node !== style.parentPath.node;
 
           if (isArrayWithJoin(css.node.value)) {
-            var elements = css.node.value.expression.callee.object.elements;
+            var elements = css.node.value.expression.callee.object.elements.filter(function(v) {return !!v.object});
             if (css && style) {
               style.node.value = t.arrayExpression(
                 [].concat(


### PR DESCRIPTION
When undefined or null variables is passed in array join className, this exception message was prompt : 
Property arguments[0] of CallExpression expected node to be of a type [\"Expression\",\"SpreadElement\",\"JSXNamespacedName\",\"ArgumentPlaceholder\"] but instead got undefined.

It's fixed with a filter on css.node.value.expression.callee.object.elements on line 160.